### PR TITLE
updating the local in a blocking way, so no other will update it, and…

### DIFF
--- a/flow_initiator/spawner/async_spawner.py
+++ b/flow_initiator/spawner/async_spawner.py
@@ -131,13 +131,14 @@ class Spawner(CommandValidator):
         }
         active_scene = self.robot.Status.get("active_scene", "") if data["active_flow"] else ""
         data.update({"active_scene": active_scene})
+        self.robot.update_status(data, db="local")
 
         # run robot update in a thread executor so it does not block
         await self.loop.run_in_executor(None, self.th_robot_update, self.robot.name, data)
 
     def th_robot_update(self, robot_name: str, data: dict) -> None:
         """robot update blocks, should run in a thread executor"""
-        Robot.cls_update_status(robot_name, data, db="all")
+        Robot.cls_update_status(robot_name, data, db="global")
 
     async def stop(self) -> None:
         """Stop all processes"""


### PR DESCRIPTION
updating the local in a blocking way, so no other will update it, and the global that is slower on the worker

The problem was that the scene could update while a new thread was running with the old status
so it will rewrite the new scene

this way with blocking code it set it faster and while blocking other code from running
the slow process of the updating, that is updating the global DB will still happen in a worker