### PR TITLE
version 2.4.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,3 @@ For ROS noetic distribution :
     export FLOW_INITIATOR_DISTRO=noetic
     docker-compose -f tests/docker-compose.yml up -d
 
-
-
-


### PR DESCRIPTION
movai-core-shared updated: 2.4.1.8 => 2.4.1.9
revert [BP-957](https://movai.atlassian.net/browse/BP-957) - removing tags from log message

[BP-957]: https://movai.atlassian.net/browse/BP-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ