### PR TITLE
updated gd-node version (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ For ROS noetic distribution :
     export FLOW_INITIATOR_DISTRO=noetic
     docker-compose -f tests/docker-compose.yml up -d
 
+

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "gd-node==2.4.1.*"
+    "gd-node==2.4.1.12"
 ]
 
 


### PR DESCRIPTION
[BP-568](https://movai.atlassian.net/browse/BP-568): Support for sending latched topic in gd.oport api / [BP-927](https://movai.atlassian.net/browse/BP-927): SMTP server is not receiving emails after configuring emails callback
gd-node: 2.4.1.* -> 2.4.1.12

[BP-568]: https://movai.atlassian.net/browse/BP-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-927]: https://movai.atlassian.net/browse/BP-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ