### PR TITLE
Release spawner base update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
     "movai-core-shared==2.4.1.10",
-    "data-access-layer==2.4.1.17",
+    "data-access-layer==2.4.1.18",
     "gd-node==2.4.1.13",
 ]
 


### PR DESCRIPTION
[DP-1141](https://movai.atlassian.net/browse/DP-1141) : Spawner firmware is not being installed by mobros anymore

---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[DP-1141]: https://movai.atlassian.net/browse/DP-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ