### PR TITLE
New version 2.4.1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ For ROS noetic distribution :
     export FLOW_INITIATOR_DISTRO=noetic
     docker-compose -f tests/docker-compose.yml up -d
 
+

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "movai-core-shared==2.4.1.10",
-    "data-access-layer==2.4.1.18",
-    "gd-node==2.4.1.13",
+    "movai-core-shared==2.4.1.12",
+    "data-access-layer==2.4.1.20",
+    "gd-node==2.4.1.14",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "gd-node==2.4.1.*"
+    "gd-node==2.4.1.12"
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "gd-node==2.4.1.12"
+    "movai-core-shared==2.4.1.10",
+    "data-access-layer==2.4.1.17",
+    "gd-node==2.4.1.13",
 ]
 
 
@@ -24,7 +26,7 @@ setuptools.setup(
     classifiers=["Programming Language :: Python :: 3"],
     install_requires=requirements,
     entry_points={
-        "console_scripts":[
+        "console_scripts": [
             "flow_compiler = flow_initiator.tools.flow_compiler:main",
             "flow_initiator = flow_initiator:main",
             "init_local_db = flow_initiator.tools.init_local_db:main"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
     "movai-core-shared==2.4.1.10",
-    "data-access-layer==2.4.1.17",
+    "data-access-layer==2.4.1.18",
     "gd-node==2.4.1.13",
 ]
 


### PR DESCRIPTION
- [BP-995](https://movai.atlassian.net/browse/BP-995): missing logs information
     -  the lost feature that prints tracelog on error print that happens after an exception also changed it print only LogAdapter only been used by users


[BP-995]: https://movai.atlassian.net/browse/BP-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ