### PR TITLE
DP-1239 Add version input to docker image actions

### DIFF
--- a/.github/workflows/DeployOnGitRelease.yml
+++ b/.github/workflows/DeployOnGitRelease.yml
@@ -42,6 +42,7 @@ jobs:
       public: true
       public_image: ce/flow-initiator-noetic
       deploy: true
+      version: ${GITHUB_REF#refs/*/}
       push_latest: true
       snyk_check: true
       build_args: PIP_PACKAGE_REPO=https://artifacts.cloud.mov.ai/repository/pypi-edge/simple

--- a/.github/workflows/DeployOnMergeMain.yml
+++ b/.github/workflows/DeployOnMergeMain.yml
@@ -51,6 +51,7 @@ jobs:
       public: false
       public_image: ce/flow-initiator-noetic
       deploy: true
+      version: ${{ needs.CI-version.outputs.version }}
       push_latest: true
       snyk_check: true
       build_args: PIP_PACKAGE_REPO=https://artifacts.cloud.mov.ai/repository/pypi-integration/simple

--- a/.github/workflows/TestOnPR.yml
+++ b/.github/workflows/TestOnPR.yml
@@ -56,6 +56,7 @@ jobs:
       public: false
       public_image: ce/flow-initiator-noetic
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
+      version: ${{ needs.CI-version.outputs.version }}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
       build_args: PIP_PACKAGE_REPO=https://artifacts.cloud.mov.ai/repository/pypi-experimental/simple


### PR DESCRIPTION
Add 'version' input to docker image action.

Pipeline Run: https://github.com/MOV-AI/flow-initiator/actions/runs/5764092857

Tag Version Generated: 2.4.1.40 (already exists in nexus)
Push Flag: False

-------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
