### PR TITLE
changed timeout to 7 sec until force kill, and unload the flow first …

### DIFF
--- a/flow_initiator/spawner/async_spawner.py
+++ b/flow_initiator/spawner/async_spawner.py
@@ -55,7 +55,7 @@ class Spawner(CommandValidator):
         self._logger = Log.get_logger("spawner.mov.ai")
         self._stdout = open(f"{APP_LOGS}/stdout", "w")
         self.loop = loop
-        self.lock = asyncio.Lock(loop=self.loop)
+        self.lock = asyncio.Lock()
         self.robot = robot
         self.debug = debug
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -181,7 +181,8 @@ class Spawner(CommandValidator):
         for node_name, value in processes.items():
             tasks.append(self.terminate_process(value, node_name))
         # wait for all get_keys tasks to run
-        _values = await asyncio.gather(*tasks)
+        self.flow_monitor.unload()
+        await asyncio.gather(*tasks)
         if gdnode_exist:
             # need to check all nodes are dead before cleaning parameter server cuz dyn req
             ROS1.clean_parameter_server()
@@ -192,7 +193,6 @@ class Spawner(CommandValidator):
         Var.delete_all(scope="Flow")
 
         self._logger.info("Spawner: flow terminated.")
-        self.flow_monitor.unload()
         self.persistent_nodes_lchd = {}
         self.nodes_lchd = {}
         self.active_states = set()
@@ -355,13 +355,12 @@ class Spawner(CommandValidator):
         # func = self.commands.get(params["command"], None)
         # if func:
         #     self.loop.create_task(func(**params))
+        await self.lock.acquire()
         try:
-            await self.lock.acquire()
-
             self.validate_command(**params, active_flow=self.flow_monitor.active_flow)
 
             await self.commands[params["command"]](**params)
-        except (CommandError, ActiveFlowError) as e:
+        except Exception as e:
             self._logger.warning(str(e))
         finally:
             self.lock.release()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "movai-core-shared==2.4.1.26",
+    "movai-core-shared==2.4.1.27",
     "data-access-layer==2.4.1.35",
     "gd-node==2.4.1.17",
 ]


### PR DESCRIPTION
- changed the timeout to 7 seconds until force kill, helps with fast transition and can reduce the problem with a node that refuses to die
- Unload the flow first thing, that will make sure that no transition can happen when the flow is stopped
- Lock outside the try block, and update the lock with a loop, that causes a deprecation warning
- increased the catch to catch any type of exception, for better stability for the spawner
see
https://github.com/MOV-AI/movai-core-shared/pull/103