### PR TITLE
Ver 2.4.1.46

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.1-43
+current_version = 2.4.1-44
 commit = True
 message = 
 	[skip actions] Automatic version bump {current_version} -> {new_version}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "movai-core-shared==2.4.1.24",
+    "movai-core-shared==2.4.1.26",
     "data-access-layer==2.4.1.35",
     "gd-node==2.4.1.17",
 ]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
 
 setuptools.setup(
     name="flow-initiator",
-    version="2.4.1-43",
+    version="2.4.1-44",
     author="Backend team",
     author_email="backend@mov.ai",
     description="Dummy description",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "movai-core-shared==2.4.1.27",
     "data-access-layer==2.4.1.35",
-    "gd-node==2.4.1.17",
+    "gd-node==2.4.1.18",
 ]
 
 


### PR DESCRIPTION
A new version with the latest fixes:
 - [BP-944](https://movai.atlassian.net/browse/BP-944): State Node port callbacks called after transitioning
 - [BP-1063](https://movai.atlassian.net/browse/BP-1063):Configuration parameter changes are not taking any effect
 - [BP-1058](https://movai.atlassian.net/browse/BP-1058): GDNodes fail to trigger callbacks on latched/other topics

[BP-944]: https://movai.atlassian.net/browse/BP-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1063]: https://movai.atlassian.net/browse/BP-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1058]: https://movai.atlassian.net/browse/BP-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ