### PR TITLE
Ver 2.4.1.48

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "movai-core-shared==2.4.1.30",
     "data-access-layer==2.4.1.35",
-    "gd-node==2.4.1.19",
+    "gd-node==2.4.1.20",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "movai-core-shared==2.4.1.27",
+    "movai-core-shared==2.4.1.30",
     "data-access-layer==2.4.1.35",
     "gd-node==2.4.1.19",
 ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "movai-core-shared==2.4.1.27",
     "data-access-layer==2.4.1.35",
-    "gd-node==2.4.1.18",
+    "gd-node==2.4.1.19",
 ]
 
 


### PR DESCRIPTION
Update gd node for the fixes:
 - [BP-330](https://movai.atlassian.net/browse/BP-330): [spawner][logs] remove redundant logs when transitioning between states:
     - Changed the verbosity from info to debug, see comments in the jira ticket
 -  [BP-994](https://movai.atlassian.net/browse/BP-994): State Node port callbacks called after transitioning
 -  [BP-1085](https://movai.atlassian.net/browse/BP-1085): GDnode callbacks are triggered before node finished initializing
 

[BP-330]: https://movai.atlassian.net/browse/BP-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-994]: https://movai.atlassian.net/browse/BP-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1085]: https://movai.atlassian.net/browse/BP-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ