### PR TITLE
Version: 2.4.1.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ For ROS noetic distribution :
 Cleaning :
 
     docker-compose -f tests/docker-compose.yml down --remove-orphans --volumes
+

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
     "movai-core-shared==2.4.1.30",
-    "data-access-layer==2.4.1.35",
-    "gd-node==2.4.1.20",
+    "data-access-layer==2.4.1.36",
+    "gd-node==2.4.1.21",
 ]
 
 


### PR DESCRIPTION
- [BP-1097](https://movai.atlassian.net/browse/BP-1097): Excessive log Node/Dummy when starting a flow
  - data-access-layer: 2.4.1.35 -> 2.4.1.36
- [BP-944](https://movai.atlassian.net/browse/BP-944): State Node port callbacks called after transitioning
  - gd-node: 2.4.1.20 -> 2.4.1.21

[BP-1097]: https://movai.atlassian.net/browse/BP-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-944]: https://movai.atlassian.net/browse/BP-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ