### PR TITLE
DP-1279 Bump spawner with ppa proxy backups

### DIFF
--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -1,7 +1,7 @@
 ARG DOCKER_REGISTRY="registry.cloud.mov.ai"
 ARG ENV="qa"
 ARG BASE_IMAGE="spawner-base-noetic"
-ARG TAG="v3.1.27"
+ARG TAG="v3.1.28"
 
 # === Flow-Initiator
 FROM ${DOCKER_REGISTRY}/${ENV}/${BASE_IMAGE}:${TAG} AS Flow-Initiator


### PR DESCRIPTION
Nexus migration requires proxied cached packages to be in a backup repo that wasn't in the ros containers before.