### PR TITLE
DP-1384: change spawner ZMQ server address to unix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0-7
+current_version = 2.5.0-9
 commit = True
 message = 
 	[skip actions] Automatic version bump {current_version} -> {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0-9
+current_version = 2.5.0.12
 commit = True
 message = 
 	[skip actions] Automatic version bump {current_version} -> {new_version}

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # .deb
 debian/flow-initiator/DEBIAN/
 debian/.debhelper
+.testenv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    - id: check-docstring-first     # checks if docstring is before code
+    - id: check-json                # checks if json files are valid
+    - id: check-added-large-files   # checks if large files were added
+    - id: check-merge-conflict      # checks if all merge conflicts were resolved
+    - id: check-yaml                # checks if yaml files are valid
+    - id: debug-statements          # checks if debug statements are to be commited
+    - id: end-of-file-fixer         # fixes missing line ending in end of file
+    - id: mixed-line-ending         # fixes line files line ending
+      args: [--fix=lf]
+    - id: trailing-whitespace       # removes trailing whitespaces from text files
+      exclude: .bumpversion.cfg     # a tool edits this file and leaves trailing spaces, must be ignored
+
+  - repo: https://github.com/ambv/black     # formats Python code
+    rev: 22.8.0
+    hooks:
+    - id: black
+      args: [--line-length=100]
+
+  - repo: https://github.com/pycqa/flake8   # static tests Python code
+    rev: 7.0.0
+    hooks:
+    - id: flake8
+
+  - repo: local
+    hooks:
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        require_serial: true

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,11 +1,5 @@
 [MESSAGES CONTROL]
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        no-self-use,
-        logging-fstring-interpolation
+disable=logging-fstring-interpolation
 ignore=setup.py,
 ignore-patterns=.*_test.*?py,.*test_.*?py,.*test.*?py,.*pb2.*,.*yml, .*toml, .*txt, .*md
 

--- a/README.md
+++ b/README.md
@@ -31,34 +31,44 @@ The complete build process requires 2 steps :
 
 ## build pip module
 
-    rm dist/*
-    python3 -m build .
+```bash
+rm dist/*
+python3 -m build .
+```
 
 ## install pip module locally
 
-    python3 -m venv .testenv
-    source .testenv/bin/activate
-    python3 -m pip install --no-cache-dir \
-    --index-url="https://artifacts.cloud.mov.ai/repository/pypi-experimental/simple" \
-    --extra-index-url https://pypi.org/simple \
-    ./dist/*.whl
+```bash
+python3 -m venv .testenv
+source .testenv/bin/activate
+python3 -m pip install --no-cache-dir \
+--index-url="https://artifacts.cloud.mov.ai/repository/pypi-experimental/simple" \
+--extra-index-url https://pypi.org/simple \
+./dist/*.whl
+```
 
 ## build docker images
 
 For ROS noetic distribution :
 
-    docker build -t flow_initiator:noetic -f docker/noetic/Dockerfile .
-
+```bash
+docker build -t flow_initiator:noetic -f docker/noetic/Dockerfile .
+```
 
 ## Basic Run
 
 For ROS noetic distribution :
 
-    docker run -t flow_initiator:noetic
+```bash
+docker run -t flow_initiator:noetic
+```
 
 You don't need to worry about the 4th digit, as the CI system does the automatic bump of it.
 =======
-    docker run -t flow_initiator:noetic
+
+```bash
+docker run -t flow_initiator:noetic
+```
 
 ## Development stack
 

--- a/flow_initiator/spawner/container_tools/container_manager.py
+++ b/flow_initiator/spawner/container_tools/container_manager.py
@@ -64,6 +64,7 @@ class ContainerManager(DockerBaseManager):
         Args:
             container_name: name of the container
             cmd: command to execute
+            **kwargs: extra arguments to pass to the ``docker exec`` command.
 
         Returns:
             (ExecResult): A tuple of (exit_code, output)

--- a/flow_initiator/spawner/container_tools/orchestrator.py
+++ b/flow_initiator/spawner/container_tools/orchestrator.py
@@ -369,18 +369,19 @@ class Orchestrator:
         self._images.tag_image(commit_image, new_repo=repo, new_tag=snapshot_tag)
         return snapshot_tag
 
-    def container_execute_command(self, name: str, cmd: str):
+    def container_execute_command(self, name: str, cmd: str, **kwargs):
         """
         Run a command on a running container
         Args:
             name: name of the container
             cmd: command to run
+            **kwargs: extra arguments for the command
 
          Returns:
         (ExecResult): A tuple of (exit_code, output)
 
         """
-        return self._containers.container_execute_command(name, cmd)
+        return self._containers.container_execute_command(name, cmd, **kwargs)
 
     container_execute_command.__doc__ = (
         ContainerManager.container_execute_command.__doc__

--- a/flow_initiator/spawner/elements/attached_element.py
+++ b/flow_initiator/spawner/elements/attached_element.py
@@ -7,7 +7,6 @@
    Developers:
    - Dor Marcous  (dor@mov.ai) - 2021
 """
-import threading
 from typing import Tuple, Optional
 from movai_core_shared.exceptions import CommandError
 from flow_initiator.spawner.elements import ContainerLauncher
@@ -40,6 +39,11 @@ class AttachedProcessLauncher(ContainerLauncher):
         self.exit_code = None
         self.output = None
         self.running_thread = None
+        self.cont_name = self.name
+        self.name = self.cmd[self.cmd.index("-n") + 1]
+        self.pid = 0
+        self.running = False
+        self.exec_outputs = None
 
     @property
     def return_code(self) -> Optional[int]:
@@ -48,9 +52,7 @@ class AttachedProcessLauncher(ContainerLauncher):
     @property
     def eid(self) -> Tuple[str, int]:
         # todo add feature to orchestrator something like docker container top, and filter by CMD
-        if self.running_thread is None:
-            return self.name, 0
-        return self.name, self.running_thread.ident
+        return self.name, self.pid
 
     async def is_running(self) -> bool:
         """
@@ -59,7 +61,27 @@ class AttachedProcessLauncher(ContainerLauncher):
         Returns: True if running, False otherwise
 
         """
-        return self.running_thread is not None and self.running_thread.is_alive()
+        return self.running
+
+    def check_and_update(self):
+        try:
+
+            _, process_list = self._orchestrator.container_execute_command(self.cont_name, "ps aux", user="root")
+            process_list = str(process_list).split("\\n")
+            for proc in process_list:
+                if "-n" in proc:
+                    list_proc = proc.split()
+                    node_name = list_proc[list_proc.index("-n") + 1]
+                    if node_name == self.name:
+                        self.pid = list_proc[1]
+                        self.running = True
+                        return
+        except Exception as e:
+            self._logger.error(e)
+        self.parse_outptus()
+        self.running = False
+        if self.exit_code is None:
+            self.exit_code = 0
 
     def handler(self):
         """
@@ -68,11 +90,17 @@ class AttachedProcessLauncher(ContainerLauncher):
         Returns: None
 
         """
-        exec_outputs = self._orchestrator.container_execute_command(self.name, self.cmd)
-        if exec_outputs is not None:
-            self.exit_code, self.output = exec_outputs
-        else:
-            self._logger.error(f"container {self.name} isn't running can't attach")
+        try:
+            self.exec_outputs = self._orchestrator.container_execute_command(self.cont_name, self.cmd, detach=True)
+            self.parse_outptus()
+
+        except Exception as e:
+            self._logger.error(e)
+        self.check_and_update()
+
+    def parse_outptus(self):
+        if self.exec_outputs is not None:
+            self.exit_code, self.output = self.exec_outputs
 
     async def run(self):
         """
@@ -81,7 +109,7 @@ class AttachedProcessLauncher(ContainerLauncher):
         Returns: None
 
         """
-        self.running_thread = threading.Thread(target=self.handler).start()
+        self.handler()
 
     async def kill(self):
         """
@@ -89,20 +117,20 @@ class AttachedProcessLauncher(ContainerLauncher):
         Returns: None
 
         """
-        if self.running_thread is not None:
-            self.running_thread.join()
+        self.send_terminate_signal()
+        await self.ensure_process_kill()
 
     def send_terminate_signal(self):
         """
         send SIGTERM to process
         """
-        if self.running_thread is not None:
-            self.running_thread.join()
+        # for attached processes only send kill signals
+        self.send_kill_signal()
 
     def send_kill_signal(self):
         """
         send SIGKILL to process
         """
-        _, pid = self.eid
-        kill_cmd = f"kill -9 {pid}"
-        self._orchestrator.container_execute_command(self.name, kill_cmd)
+        kill_cmd = f"kill -9 {self.pid}"
+        self._orchestrator.container_execute_command(self.cont_name, kill_cmd)
+        self.check_and_update()

--- a/flow_initiator/spawner/elements/elements_factory.py
+++ b/flow_initiator/spawner/elements/elements_factory.py
@@ -78,3 +78,15 @@ class ElementsFactory:
                 )
         await elem.run()
         return elem
+
+    async def remove_all_containers(self):
+        """
+        remove all containers
+        Returns: None
+
+        """
+        if self.orchestrator is None:
+            return
+        # Todo make it async
+        for container in ContainerLauncher.flow_containers:
+            self.orchestrator.container_remove(container)

--- a/flow_initiator/spawner/spawner.py
+++ b/flow_initiator/spawner/spawner.py
@@ -204,7 +204,7 @@ class Spawner:
             tasks.append(asyncio.create_task(value.kill()))
         # wait for all get_keys tasks to run
         await asyncio.gather(*tasks)
-
+        await self.factory.remove_all_containers()
         self.persistent_nodes_lchd = {}
         self.nodes_lchd = {}
         self.core_lchd = {}
@@ -229,6 +229,7 @@ class Spawner:
         # wait for all get_keys tasks to run
         self.flow_monitor.unload()
         await asyncio.gather(*tasks)
+        await self.factory.remove_all_containers()
         if gdnode_exist:
             # need to check all nodes are dead before cleaning parameter server cuz dyn req
             ROS1.clean_parameter_server()
@@ -307,12 +308,7 @@ class Spawner:
         """
         persistent = kwargs.pop("persistent", False)
         self._logger.info(
-            (
-                "Launching command (persistent: {}) {}".format(
-                    persistent, " ".join(command)
-                )
-            )
-        )
+                "Launching command (persistent: {}) {}".format(persistent, " ".join(command)))
         cwd = cwd or self.temp_dir.name
         elem = None
         try:
@@ -433,9 +429,7 @@ class Spawner:
             # they also need to be activated
             ros2_lifecycle_nodes_to_activate = []
             for lc_node in self.flow_monitor.load_ros2_lifecycle():
-                if lc_node["node"] not in [
-                    command["node"] for command in commands_to_launch
-                ]:
+                if lc_node["node"] not in [command["node"] for command in commands_to_launch]:
                     commands_to_launch.append(lc_node)
                 else:
                     ros2_lifecycle_nodes_to_activate.append(lc_node["node"])

--- a/flow_initiator/spawner/spawner_core.py
+++ b/flow_initiator/spawner/spawner_core.py
@@ -17,7 +17,6 @@ import aioredis
 import rospy
 
 from movai_core_shared.logger import Log
-
 from dal.scopes.robot import Robot
 from dal.models.lock import Lock
 from dal.movaidb import RedisClient

--- a/flow_initiator/spawner/spawner_manager.py
+++ b/flow_initiator/spawner/spawner_manager.py
@@ -10,19 +10,16 @@ import argparse
 import asyncio
 import traceback
 
-from beartype import beartype
-
 from movai_core_shared.logger import Log
-
 from dal.scopes.robot import Robot
 
 from flow_initiator.spawner.spawner_core import SpawnerCore
 from flow_initiator.spawner.spawner import Spawner
 from flow_initiator.spawner.spawner_server import SpawnerServer
 
-spawner_logger = "spawner.mov.ai"
-LOGGER = Log.get_logger(spawner_logger)
-USER_LOGGER = Log.get_user_logger(spawner_logger)
+SPAWNER_LOGGER = "spawner.mov.ai"
+LOGGER = Log.get_logger(SPAWNER_LOGGER)
+USER_LOGGER = Log.get_user_logger(SPAWNER_LOGGER)
 
 
 def handle_exception(context):
@@ -36,9 +33,7 @@ def handle_exception(context):
 
     """
     msg = context.get("exception", context["message"])
-    tb_str = traceback.format_exception(
-        etype=type(msg), value=msg, tb=msg.__traceback__
-    )
+    tb_str = traceback.format_exception(etype=type(msg), value=msg, tb=msg.__traceback__)
     USER_LOGGER.error("\n" + "".join(tb_str))
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,16 @@ with open("README.md", "r") as fh:
 requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
-    "docker==6.1.0",
+    "docker==6.1.2",
     "movai-core-shared==2.5.0.6",
     "data-access-layer==2.5.0.6",
-    "gd-node==2.5.0.5"
+    "gd-node==2.5.0.6"
 ]
 
 
 setuptools.setup(
     name="flow-initiator",
-    version="2.5.0-7",
+    version="2.5.0-9",
     author="Backend team",
     author_email="backend@mov.ai",
     description="Dummy description",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 setuptools.setup(
     name="flow-initiator",
-    version="2.5.0-9",
+    version="2.5.0.12",
     author="Backend team",
     author_email="backend@mov.ai",
     description="Dummy description",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "docker==6.1.2",
     "movai-core-shared==2.5.0.12",
-    "data-access-layer==2.5.0.10",
+    "data-access-layer==2.5.0.12",
     "gd-node==2.5.0.6"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ requirements = [
     "aioredis==1.3.1",
     "uvloop==0.14.0",
     "docker==6.1.2",
-    "movai-core-shared==2.5.0.6",
-    "data-access-layer==2.5.0.6",
+    "movai-core-shared==2.5.0.12",
+    "data-access-layer==2.5.0.10",
     "gd-node==2.5.0.6"
 ]
 


### PR DESCRIPTION
ZMQ socket not working in hostmode=true

## goal
replace ZMQ communication with spawner from TCP to a unix file socket shared between containers

## content
- [change spawner ZMQ server address to unix](https://github.com/MOV-AI/flow-initiator/pull/134/commits/2a45615ff5bc477572273249a3b522ec91ca3ad3)
- [Merge tag '2.5.0.9' into fix/DP-1384](https://github.com/MOV-AI/flow-initiator/pull/134/commits/3c5048c70de03537feb7ad1a7d0f9f1f4674c772)
- use core shared value for SPAWNER_BIND_ADDR

## relates to PRs
- movai-core-shared: TO_BE_RELEASED first
  -  https://github.com/MOV-AI/movai-core-shared/pull/144
- dal: TO_BE_RELEASED first
  - https://github.com/MOV-AI/data-access-layer/pull/202
- backend:
- message-server:https://github.com/MOV-AI/message-server/pull/148

