### PR TITLE
Version 2.5.0.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "docker==6.1.2",
     "movai-core-shared==2.5.0.12",
-    "data-access-layer==2.5.0.12",
+    "data-access-layer==2.5.0.13",
     "gd-node==2.5.0.9"
 ]
 


### PR DESCRIPTION
Update DAL to [2.5.0.13](https://github.com/MOV-AI/data-access-layer/releases/tag/2.5.0.13) in order to apply fix for [BP-1166](https://movai.atlassian.net/browse/BP-1166).

[BP-1166]: https://movai.atlassian.net/browse/BP-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ