### PR TITLE
Fixed init_local_db hanging by force killing it

### DIFF
--- a/flow_initiator/tools/init_local_db.py
+++ b/flow_initiator/tools/init_local_db.py
@@ -20,6 +20,8 @@ def main():
     """initialize redis local db"""
     Message.export_portdata(db="local")
     Callback.export_modules()
+    # TODO: this is a bit overkill, we should change how we are getting all the python packages/modules (without actually executing)
+    # export module is launching a set of processes that might run unwanted code => Security risk
     os.kill(os.getpid(), signal.SIGKILL)
 
 

--- a/flow_initiator/tools/init_local_db.py
+++ b/flow_initiator/tools/init_local_db.py
@@ -14,12 +14,13 @@
 
 from dal.models.message import Message
 from dal.models.callback import Callback
-
+import os, signal
 
 def main():
     """initialize redis local db"""
     Message.export_portdata(db="local")
     Callback.export_modules()
+    os.kill(os.getpid(), signal.SIGKILL)
 
 
 if __name__ == "__main__":

--- a/flow_initiator/tools/init_local_db.py
+++ b/flow_initiator/tools/init_local_db.py
@@ -11,10 +11,12 @@
         System:PyModules
 
 """
+import os
+import signal
 
-from dal.models.message import Message
 from dal.models.callback import Callback
-import os, signal
+from dal.models.message import Message
+
 
 def main():
     """initialize redis local db"""


### PR DESCRIPTION
Fixed process hanging by force killing the init_local_db.

It was hanging here:
```
i_mod = importlib.import_module(mod)
```

:warning: Importing EVERY system and python package is a serious security risk, we should revise this in the future