### PR TITLE
BP-1210 Subscription to changes on redis via ws/subscribe fails silently

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "docker==6.1.2",
     "movai-core-shared==2.5.0.14",
-    "data-access-layer==2.5.0.17",
+    "data-access-layer==2.5.0.18",
     "gd-node==2.5.0.10"
 ]
 


### PR DESCRIPTION
[BP-1210](https://movai.atlassian.net/browse/BP-1210) Update to the latest data-acces-layer, which contains a fix to close redis connections when websocket session ends

[BP-1210]: https://movai.atlassian.net/browse/BP-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ