### PR TITLE
Explicitly connect to redis

### DIFF
--- a/flow_initiator/tools/init_local_db.py
+++ b/flow_initiator/tools/init_local_db.py
@@ -16,10 +16,17 @@ import signal
 
 from dal.models.callback import Callback
 from dal.models.message import Message
+from dal.movaidb import MovaiDB
 
 
 def main():
     """initialize redis local db"""
+
+    # Connect to DBs
+    MovaiDB(db="global")
+    MovaiDB(db="local")
+
+    # Load data
     Message.export_portdata(db="local")
     Callback.export_modules()
     # TODO: this is a bit overkill, we should change how we are getting all the python packages/modules (without actually executing)


### PR DESCRIPTION
During development of [BP-944](https://movai.atlassian.net/browse/BP-944), it was detected that the init_local_db tool depended on a side-effect of SecretKey, and broke when that class was changed. This PR fixes that.

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
~- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-944]: https://movai.atlassian.net/browse/BP-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ