### PR TITLE
BP-1245: Ignore empty patterns of nodes "not to be killed" during emergency

### DIFF
--- a/flow_initiator/spawner/spawner.py
+++ b/flow_initiator/spawner/spawner.py
@@ -141,6 +141,8 @@ class Spawner:
         """
 
         for regex_object in self.nodes_to_skip:
+            if len(regex_str) == 0:
+                continue
             if regex_object.match(node_name) is not None:
                 return True
         return False


### PR DESCRIPTION
When a regex pattern is empty, the match function will match it with any string, so all nodes were being selected as "not to be killed" when the emergency was triggered.

This commit makes the code ignore empty patterns.

Ported from https://github.com/MOV-AI/movai_classes/pull/199

Ticket: [BP-1245](https://movai.atlassian.net/browse/BP-1245)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1245]: https://movai.atlassian.net/browse/BP-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ