### PR TITLE
Rollout dal 2.5.0.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "uvloop==0.14.0",
     "docker==6.1.2",
     "movai-core-shared==2.5.0.18",
-    "data-access-layer==2.5.0.28",
+    "data-access-layer==2.5.0.29",
     "gd-node==2.5.0.18"
 ]
 


### PR DESCRIPTION
Adding the __len__ caused Python to change its behavior when the code tests the truthiness of the object (as in, if obj:).

Also cleaning up a warning that was way too verbose.

TIcket: [BP-1259](https://movai.atlassian.net/browse/BP-1259)
Rollout dal 2.5.0.29

[BP-1259]: https://movai.atlassian.net/browse/BP-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ